### PR TITLE
IN-41 init: add alertmodal, emailsentmodal

### DIFF
--- a/src/features/auth/ui/email-sent-modal/ui/EmailSentModal.tsx
+++ b/src/features/auth/ui/email-sent-modal/ui/EmailSentModal.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { AlertModal } from '@/src/shared/ui/AlertModal/AlertModal';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  email: string;
+};
+
+export const EmailSentModal = ({ open, onOpenChange, email }: Props) => {
+  const message = `We have sent a link to confirm your email to ${email}`;
+  return <AlertModal open={open} onOpenChange={onOpenChange} title="Email sent" message={message} confirmText="OK" />;
+};

--- a/src/features/auth/ui/email-sent-modal/ui/index.ts
+++ b/src/features/auth/ui/email-sent-modal/ui/index.ts
@@ -1,0 +1,1 @@
+export { EmailSentModal } from './EmailSentModal';

--- a/src/shared/ui/AlertModal/AlertModal.module.scss
+++ b/src/shared/ui/AlertModal/AlertModal.module.scss
@@ -1,0 +1,17 @@
+.body {
+  padding-top: 30px;
+  padding-bottom: 36px;
+}
+
+.message {
+  color: var(--color-light-100);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+  padding-bottom: 18px;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/shared/ui/AlertModal/AlertModal.stories.tsx
+++ b/src/shared/ui/AlertModal/AlertModal.stories.tsx
@@ -1,0 +1,51 @@
+// src/shared/ui/AlertModal/AlertModal.stories.tsx
+import type { Meta } from '@storybook/nextjs';
+import { useState } from 'react';
+import { AlertModal } from '@/src/shared/ui/AlertModal/AlertModal';
+import { EmailSentModal } from '@/src/features/auth/ui/email-sent-modal/ui/EmailSentModal';
+
+const meta: Meta<typeof AlertModal> = {
+  title: 'UI/AlertModal',
+  component: AlertModal,
+  tags: ['autodocs']
+};
+
+export default meta;
+
+// 🔹 Playground (базовый пример)
+export const Playground = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        style={{
+          padding: '8px 16px',
+          background: '#4c6ef5',
+          color: '#fff',
+          border: 'none',
+          borderRadius: 4,
+          cursor: 'pointer'
+        }}
+        onClick={() => setOpen(true)}
+      >
+        Open AlertModal
+      </button>
+
+      <AlertModal
+        open={open}
+        onOpenChange={setOpen}
+        title="Info"
+        message="This is an informational alert."
+        confirmText="Got it"
+      />
+    </>
+  );
+};
+
+// 🔹 Вариант через EmailSentModal
+export const EmailSentExample = () => {
+  const [open, setOpen] = useState(true);
+
+  return <EmailSentModal open={open} onOpenChange={setOpen} email="epam@epam.com" />;
+};

--- a/src/shared/ui/AlertModal/AlertModal.tsx
+++ b/src/shared/ui/AlertModal/AlertModal.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Modal } from '../Modal';
+import { Button } from '../Button/Button';
+import styles from './AlertModal.module.scss';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  message: ReactNode;
+  confirmText?: string;
+  onConfirm?: () => void;
+};
+export const AlertModal = ({ open, onOpenChange, title, message, confirmText = 'OK', onConfirm }: Props) => {
+  const handleConfirm = () => {
+    onConfirm?.();
+    onOpenChange(false);
+  };
+
+  const sizeButton = { minWidth: 96, height: 36 };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} size="sm" title={title} bodyClassName={styles.body}>
+      <div className={styles.message}>{message}</div>
+      <div className={styles.footer}>
+        <Button onClick={handleConfirm} size={sizeButton}>
+          {confirmText}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/shared/ui/AlertModal/index.ts
+++ b/src/shared/ui/AlertModal/index.ts
@@ -1,0 +1,1 @@
+export { AlertModal } from './AlertModal';

--- a/src/shared/ui/Modal/Modal.module.scss
+++ b/src/shared/ui/Modal/Modal.module.scss
@@ -48,6 +48,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
   &:hover {
     transform: scale(1.2);
   }
@@ -79,14 +80,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 24px;
+  padding: 18px 24px;
 }
 
 .headerDefault {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 24px;
+  padding: 18px 24px;
   position: relative;
   margin: 0 -24px; // компенсируем padding контента
 

--- a/src/shared/ui/Modal/Modal.stories.tsx
+++ b/src/shared/ui/Modal/Modal.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 
 const meta: Meta<typeof Modal> = {
-  title: 'Shared/Modal',
+  title: 'UI/Modal',
   component: Modal,
   parameters: {
     docs: {

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ComponentPropsWithoutRef, ReactNode } from 'react';
 import CloseIcon from '@/src/shared/assets/icons/close.svg';
 import * as Dialog from '@radix-ui/react-dialog';
@@ -15,6 +17,9 @@ export type ModalProps = {
   closeButtonPosition?: 'inside' | 'outside' | 'none';
   containerClassName?: string;
   contentClassName?: string;
+  bodyClassName?: string;
+  closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
 } & ComponentPropsWithoutRef<'div'>;
 
 export const Modal = (props: ModalProps) => {
@@ -29,6 +34,9 @@ export const Modal = (props: ModalProps) => {
     containerClassName,
     contentClassName,
     closeButtonPosition = 'inside',
+    bodyClassName,
+    closeOnOverlayClick = false,
+    closeOnEsc = false,
     ...restProps
   } = props;
 
@@ -38,7 +46,15 @@ export const Modal = (props: ModalProps) => {
         {trigger && <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>}
         <Dialog.Portal>
           <Dialog.Overlay className={styles.overlay} />
-          <Dialog.Content className={clsx(styles.content, styles[size], contentClassName)}>
+          <Dialog.Content
+            className={clsx(styles.content, styles[size], contentClassName)}
+            onInteractOutside={(e) => {
+              if (!closeOnOverlayClick) e.preventDefault();
+            }}
+            onEscapeKeyDown={(e) => {
+              if (!closeOnEsc) e.preventDefault();
+            }}
+          >
             {/* Кастомный header или дефолт, смотря что родитель передает */}
             {headerContent ? (
               <div className={styles.header}>{headerContent}</div>
@@ -61,7 +77,7 @@ export const Modal = (props: ModalProps) => {
               )
             )}
 
-            <div className={styles.body}>{children}</div>
+            <div className={clsx(styles.body, bodyClassName)}>{children}</div>
 
             {closeButtonPosition === 'outside' && (
               <Dialog.Close asChild>


### PR DESCRIPTION
**Базовый Modal**
Добавлены кастомные пропсы для стилей: bodyClassName
Закрытие модалки: 
По умолчанию теперь модалка закрывается только по кнопке (крестик/OK).
Добавлены пропсы:
- closeOnOverlayClick
- closeOnEsc
Если их не передавать → клик по фону и Escape заблокированы.

Реализован обёрточный компонент **AlertModal** на основе **Modal**
Реализован компонент **EmailSentModal** на основе  **AlertModal**
Сделала контролируемые истории для **AlertModal** с использованием **EmailSentModal**