### PR TITLE
IN-57 fix: fix error handler Sing Up

### DIFF
--- a/src/features/auth/ui/ConfirmCode/ConfirmCode.tsx
+++ b/src/features/auth/ui/ConfirmCode/ConfirmCode.tsx
@@ -63,6 +63,4 @@ export const ConfirmCode = ({ searchParams }: SearchParams) => {
   }, [path, router]);
 
   if (!code) return <div>Loading...</div>;
-
-  return <div></div>;
 };

--- a/src/features/auth/ui/ConfirmCode/ConfirmCode.tsx
+++ b/src/features/auth/ui/ConfirmCode/ConfirmCode.tsx
@@ -10,7 +10,6 @@ import {
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useConfirmRegistrationMutation } from '@/src/features/auth/api/authApi';
-import { AlertModal } from '@/src/shared/ui/AlertModal';
 
 type SearchParams = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -26,7 +25,6 @@ export const ConfirmCode = ({ searchParams }: SearchParams) => {
   const [confirmRegistration] = useConfirmRegistrationMutation();
   const [params, setParams] = useState<{ [key: string]: string | string[] | undefined } | null>(null);
 
-  const [isModal, setIsModal] = useState<ModalData>({ open: false, title: '', message: '' });
   const [status, setStatus] = useState<Status | null>(null);
 
   const path = getRedirectPath(status);
@@ -52,7 +50,7 @@ export const ConfirmCode = ({ searchParams }: SearchParams) => {
         }
       } catch (error) {
         const err = error as ConfirmCodeError;
-        handleConfirmLinkError(err, setIsModal, setStatus);
+        handleConfirmLinkError(err, setStatus);
       }
     };
     confirmCode();
@@ -66,17 +64,5 @@ export const ConfirmCode = ({ searchParams }: SearchParams) => {
 
   if (!code) return <div>Loading...</div>;
 
-  return (
-    <div>
-      {isModal.open && (
-        <AlertModal
-          open={isModal.open}
-          onOpenChange={(open) => setIsModal((prev) => ({ ...prev, open }))}
-          title={isModal.title}
-          message={isModal.message}
-          onConfirm={() => setStatus('invalid')}
-        />
-      )}
-    </div>
-  );
+  return <div></div>;
 };

--- a/src/features/auth/ui/ConfirmCode/utils/getRedirectPath.ts
+++ b/src/features/auth/ui/ConfirmCode/utils/getRedirectPath.ts
@@ -1,12 +1,11 @@
 import { ROUTES } from '@/src/shared/config/routes';
 
-export type Status = 'confirmed' | 'invalid' | 'expired';
+export type Status = 'confirmed' | 'invalid';
 type Paths = Record<Status, string>;
 
 const paths: Paths = {
   confirmed: ROUTES.AUTH.EMAIL_VERIFICATION_CONFIRMED,
-  invalid: ROUTES.AUTH.SIGN_IN,
-  expired: ROUTES.AUTH.EMAIL_VERIFICATION_EXPIRED
+  invalid: ROUTES.AUTH.EMAIL_VERIFICATION_EXPIRED
 };
 
 export const getRedirectPath = (status: Status | null) => {

--- a/src/features/auth/ui/ConfirmCode/utils/handleConfirmLinkError.ts
+++ b/src/features/auth/ui/ConfirmCode/utils/handleConfirmLinkError.ts
@@ -1,4 +1,3 @@
-import { ModalData } from '@/src/features/auth/ui/ConfirmCode/ConfirmCode';
 import { Status } from '@/src/features/auth/ui/ConfirmCode/utils/getRedirectPath';
 
 export type ConfirmCodeError = {
@@ -11,23 +10,15 @@ export type ConfirmCodeError = {
 };
 
 export const confirmLinkErrorMessage = {
-  invalid: 'Confirmation code is invalid',
-  expired: 'Confirmation code is expired'
+  invalid: 'Confirmation code is invalid'
 };
 
-export const handleConfirmLinkError = (
-  error: ConfirmCodeError,
-  setIsModal: (modalData: ModalData) => void,
-  setStatus: (status: Status | null) => void
-) => {
+export const handleConfirmLinkError = (error: ConfirmCodeError, setStatus: (status: Status | null) => void) => {
   const errorMessage = error?.data?.messages[0].message || undefined;
 
   switch (errorMessage) {
     case confirmLinkErrorMessage.invalid:
-      setIsModal({ open: true, title: 'User is exist', message: 'Go to the Sign In page' });
-      break;
-    case confirmLinkErrorMessage.expired:
-      setStatus('expired');
+      setStatus('invalid');
       break;
     default:
       return;


### PR DESCRIPTION
Оказалось, что при не валидной ссылке, и при истёкшей одна и та же ошибка: Confirmation link is invalid. 
Убрал вторую ошибку expired, убрал модальное окно.

Текст ошибки link is invalid, но переводит на страницу Link is expired и константа маршрута expired)

Теперь в компоненте ConfirmCode только два сценария:
1. Если код подтверждён — отправляет на страницу Congratulations -> Sign In.
2. Если код не валидный — отправляет на страницу Link expired. 